### PR TITLE
Changes to Helm Chart, Dockerfile & Codefresh yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
-FROM golang:1.7.1 AS build-env
-COPY src /go/src
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/sample src/sample/trivial-web-server.go
+FROM golang:1.14
 
-FROM scratch
-COPY --from=build-env /go/bin/sample /app/sample
+# Copy everything from the current directory to the PWD (Present Working Directory) inside the container
+COPY . .
 
+# Download all the dependencies
+RUN go get -d -v ./...
+
+# Install the package
+RUN go install -v ./...
+
+# This container exposes port 8080 to the outside world
 EXPOSE 8080
-CMD ["/app/sample"]
+
+# Run the executable
+CMD ["sample"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,9 @@
-FROM golang:1.14
+FROM golang:1.7.1 AS build-env
+COPY src /go/src
+RUN CGO_ENABLED=0 GOOS=linux go build -o bin/sample src/sample/trivial-web-server.go
 
-# Copy everything from the current directory to the PWD (Present Working Directory) inside the container
-COPY . .
+FROM scratch
+COPY --from=build-env /go/bin/sample /app/sample
 
-# Download all the dependencies
-RUN go get -d -v ./...
-
-# Install the package
-RUN go install -v ./...
-
-# This container exposes port 8080 to the outside world
 EXPOSE 8080
-
-# Run the executable
-CMD ["sample"]
+CMD ["/app/sample"]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ And then visit http://localhost:8080 in your browser.
 
 ## Editing the chart
 
-Make sure to edit the templates and values with your own settings (e.g. docker image deployed).
+Make sure to edit the templates and values with your own settings (e.g. docker image deployed). 
+
+Specifically, 
+* kube_context: anais-cluster@codefresh-sa in the codefresh.yml
 
 ## To use this project in Codefresh
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 This is an example Go application packaged with Docker and Helm.
 It is compiled using Codefresh.
 
+To see how you can store and deploy your first Helm Chart using a Codefresh pipeline, please follow [this tutorial](https://codefresh.io/docs/docs/yaml-examples/examples/helm/).
+
 
 ## Create a multi-stage docker image
 
@@ -24,12 +26,11 @@ And then visit http://localhost:8080 in your browser.
 
 ## Editing the chart
 
-The chart was created using [Draft](draft.sh). Make sure to edit the templates and values
-with your own settings (e.g. docker image deployed).
+Make sure to edit the templates and values with your own settings (e.g. docker image deployed).
 
 ## To use this project in Codefresh
 
-There is also a [codefresh.yml](codefresh.yml) for easy usage with the [Codefresh](codefresh.io) CI/CD platform.
+There is also a [codefresh.yml](codefresh.yml) for easy usage with the [Codefresh](https://codefresh.io/) CI/CD platform.
 
 For the direct deployment without storing the helm chart first see [codefresh-do-not-store.yml](codefresh-do-not-store.yml)
 

--- a/charts/helm-example/.helmignore
+++ b/charts/helm-example/.helmignore
@@ -19,3 +19,4 @@
 .project
 .idea/
 *.tmproj
+.vscode/

--- a/charts/helm-example/Chart.yaml
+++ b/charts/helm-example/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.0
+appVersion: 2.0.0

--- a/charts/helm-example/Chart.yaml
+++ b/charts/helm-example/Chart.yaml
@@ -1,4 +1,21 @@
-apiVersion: v1
-description: A Helm chart for Kubernetes
+apiVersion: v2
 name: helm-example
-version: v0.3.0
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.0.0

--- a/charts/helm-example/templates/NOTES.txt
+++ b/charts/helm-example/templates/NOTES.txt
@@ -1,15 +1,21 @@
-
-{{- if contains "NodePort" .Values.service.type }}
-  Get the application URL by running these commands:
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "helm-example.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT/login
+  echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
-  Get the application URL by running these commands:
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
-{{- else }}
-  http://{{ .Release.Name }}.{{ .Values.basedomain }} to access your application
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "helm-example.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "helm-example.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "helm-example.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
 {{- end }}

--- a/charts/helm-example/templates/_helpers.tpl
+++ b/charts/helm-example/templates/_helpers.tpl
@@ -2,15 +2,62 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "helm-example.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
-{{- define "fullname" -}}
+{{- define "helm-example.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helm-example.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "helm-example.labels" -}}
+helm.sh/chart: {{ include "helm-example.chart" . }}
+{{ include "helm-example.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "helm-example.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "helm-example.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "helm-example.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "helm-example.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
 {{- end -}}

--- a/charts/helm-example/templates/deployment.yaml
+++ b/charts/helm-example/templates/deployment.yaml
@@ -1,27 +1,55 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ include "helm-example.fullname" . }}
   labels:
-    draft: {{ default "draft-app" .Values.draft }}
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- include "helm-example.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "helm-example.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      annotations:
-        buildID: {{ .Values.buildID }}
       labels:
-        draft: {{ default "draft-app" .Values.draft }}
-        app: {{ template "fullname" . }}
+        {{- include "helm-example.selectorLabels" . | nindent 8 }}
     spec:
+    {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        - name: {{ .Values.image.pullSecret }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "helm-example.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-      - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        ports:
-        - containerPort: {{ .Values.service.internalPort }}
-        resources:
-{{ toYaml .Values.resources | indent 12 }}
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/helm-example/templates/ingress.yaml
+++ b/charts/helm-example/templates/ingress.yaml
@@ -1,17 +1,41 @@
 {{- if .Values.ingress.enabled -}}
+{{- $fullName := include "helm-example.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ $fullName }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- include "helm-example.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
   rules:
-  - host: {{ .Release.Name }}.{{ .Values.basedomain }}
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: {{ template "fullname" . }}
-          servicePort: {{ .Values.service.externalPort }}
-{{- end -}}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/helm-example/templates/service.yaml
+++ b/charts/helm-example/templates/service.yaml
@@ -1,18 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ include "helm-example.fullname" . }}
   labels:
-    app.kubernetes.io/name: "{{ template "name" . }}"  
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    app.kubernetes.io/managed-by: "{{ .Release.Service  }}"
-    app.kubernetes.io/instance: "{{ .Release.Name }}"   
+    {{- include "helm-example.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-  - port: {{ .Values.service.externalPort }}
-    targetPort: {{ .Values.service.internalPort }}
-    protocol: TCP
-    name: {{ .Values.service.name }}
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
   selector:
-    app: {{ template "fullname" . }}
+    {{- include "helm-example.selectorLabels" . | nindent 4 }}

--- a/charts/helm-example/templates/serviceaccount.yaml
+++ b/charts/helm-example/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "helm-example.serviceAccountName" . }}
+  labels:
+{{ include "helm-example.labels" . | nindent 4 }}
+{{- end -}}

--- a/charts/helm-example/templates/tests/test-connection.yaml
+++ b/charts/helm-example/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "helm-example.fullname" . }}-test-connection"
+  labels:
+{{ include "helm-example.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "helm-example.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/helm-example/values.yaml
+++ b/charts/helm-example/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 image:
   pullPolicy: IfNotPresent
-  repository: r.cfcr.io/anna-codefresh/helm-sample-app-go
+  repository: anaisurlichs/helm-sample-app-go
 service:
   name: my-example-helm-app
   type: LoadBalancer

--- a/charts/helm-example/values.yaml
+++ b/charts/helm-example/values.yaml
@@ -1,21 +1,66 @@
-# Default values for golang.
+# Default values for helm-example.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
 replicaCount: 1
+
 image:
   pullPolicy: IfNotPresent
-  repository: anaisurlichs/helm-sample-app-go
+  repository: anaisurlichs/helm-go-example
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
 service:
-  name: my-example-helm-app
-  type: LoadBalancer
-  externalPort: 80
-  internalPort: 8080
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+  type: ClusterIP
+  port: 80
+
 ingress:
   enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/codefresh-do-not-store.yml
+++ b/codefresh-do-not-store.yml
@@ -9,8 +9,8 @@ steps:
     stage: prepare
     type: git-clone
     arguments:
-      repo: codefresh-contrib/helm-sample-app
-      revision: master
+      repo: anais-codefresh/helm-sample-app
+      revision: "${{CF_BRANCH}}"
       git: github
   build:
     title: Building Docker Image
@@ -31,10 +31,9 @@ steps:
       chart_name: charts/helm-example
       release_name: my-go-chart-prod
       helm_version: 3.0.2
-      kube_context: my-demo-k8s-cluster
+      kube_context: anais-cluster@codefresh-sa
       custom_values:
         - 'buildID=${{CF_BUILD_ID}}'
         - 'image_pullPolicy=Always'
         - 'image_tag=multi-stage'
         - 'replicaCount=3'
-        - 'image_pullSecret=codefresh-generated-r.cfcr.io-cfcr-default'

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -18,7 +18,7 @@ steps:
     type: build
     working_directory: ./helm-sample-app
     image_name: anaisurlichs/helm-go-example
-    tag: 1.0.0
+    tag: 2.0.0
     dockerfile: Dockerfile
   store:
     title: Storing Helm Chart

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -17,8 +17,8 @@ steps:
     stage: build
     type: build
     working_directory: ./helm-sample-app
-    image_name: anaisurlichs/helm-sample-app-go
-    tag: multi-stage
+    image_name: anaisurlichs/helm-go-example
+    tag: 1.0.0
     dockerfile: Dockerfile
   store:
     title: Storing Helm Chart
@@ -42,5 +42,5 @@ steps:
       custom_values:
         - 'buildID=${{CF_BUILD_ID}}'
         - 'image_pullPolicy=Always'
-        - 'image_tag=multi-stage'
+        - 'image_tag=1.0.0'
         - 'replicaCount=3'

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -30,8 +30,7 @@ steps:
     arguments:
       action: push
       chart_name: charts/helm-example
-      chart_repo_url: 'cm://h.cfcr.io/anna-codefresh/default'
-      kube_context: my-demo-k8s-cluster
+      kube_context: anais-cluster@codefresh-sa
   deploy:
     type: helm
     stage: deploy
@@ -41,7 +40,7 @@ steps:
       chart_name: charts/helm-example
       release_name: my-go-chart-prod
       helm_version: 3.0.2
-      kube_context: my-demo-k8s-cluster
+      kube_context: anais-cluster@codefresh-sa
       custom_values:
         - 'buildID=${{CF_BUILD_ID}}'
         - 'image_pullPolicy=Always'

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -9,19 +9,17 @@ steps:
     title: Cloning main repository...
     stage: prepare
     type: git-clone
-    arguments:
-      repo: codefresh-contrib/helm-sample-app
-      revision: master
-      git: github
+    repo: codefresh-contrib/helm-sample-app
+    revision: "${{CF_BRANCH}}"
+    git: github
   build:
     title: Building Docker Image
     stage: build
     type: build
     working_directory: ./helm-sample-app
-    arguments:
-      image_name: helm-sample-app-go
-      tag: multi-stage
-      dockerfile: Dockerfile
+    image_name: anaisurlichs/helm-sample-app-go
+    tag: multi-stage
+    dockerfile: Dockerfile
   store:
     title: Storing Helm Chart
     type: helm
@@ -46,4 +44,3 @@ steps:
         - 'image_pullPolicy=Always'
         - 'image_tag=multi-stage'
         - 'replicaCount=3'
-        - 'image_pullSecret=codefresh-generated-r.cfcr.io-cfcr-default'

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -27,6 +27,7 @@ steps:
     working_directory: ./helm-sample-app
     arguments:
       action: push
+      helm_version: 3.0.2
       chart_name: charts/helm-example
       kube_context: anais-cluster@codefresh-sa
   deploy:
@@ -42,5 +43,5 @@ steps:
       custom_values:
         - 'buildID=${{CF_BUILD_ID}}'
         - 'image_pullPolicy=Always'
-        - 'image_tag=1.0.0'
+        - 'image_tag=2.0.0'
         - 'replicaCount=3'


### PR DESCRIPTION
Here is what changed
* Minor edits to the Readme
* Changes to the Dockerfile
* New Helm Chart that links to a different Docker image
* Minor edits to the Codefresh yml

I can now
* Build and run the docker image
* Deploy to Kubernetes cluster using Helm
* Run the image in the cluster
* Run the codefresh pipeline